### PR TITLE
Allow to override format pattern

### DIFF
--- a/Formatter/ConsoleFormatter.php
+++ b/Formatter/ConsoleFormatter.php
@@ -155,6 +155,11 @@ class ConsoleFormatter implements FormatterInterface
         return $a;
     }
 
+    private function setFormatPattern($formatPattern)
+    {
+        $this->options['format'] = $formatPattern;
+    }
+
     private function replacePlaceHolder(array $record)
     {
         $message = $record['message'];


### PR DESCRIPTION
I'm trying to customize the default formatter for ConsoleHandler in my application to use a custom format patternfor messages.

I could set a new formatter to this Handler extending it and overwriting the `getDefaultFormatter()` method:

```php
<?php
namespace App\Logging;

use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
use Symfony\Bridge\Monolog\Handler\ConsoleHandler as BaseConsoleHandler;

/**
 * Customize Symfony console Handler formatter
 */
class ConsoleHandler extends BaseConsoleHandler
{
    protected function getDefaultFormatter()
    {
        $consoleFormatter = new ConsoleFormatter([
            'format' => "%channel% %start_tag%%level_name% %message%%end_tag%%context%\n",
            'multiline' => true
        ]);

        return $consoleFormatter;
    }
}
```

but the original method creates the formatter class [a bit different](https://github.com/symfony/monolog-bridge/blob/master/Handler/ConsoleHandler.php#L152) based on OutputInterface.

With a method to set a new format it's possible to do something like this:

```php
    protected function getDefaultFormatter()
    {
        $consoleFormatter = parent::getDefaultFormatter();
        $consoleFormatter->setFormatPattern("%channel% %start_tag%%level_name% %message%%end_tag%%context%\n");

        return $consoleFormatter;
    }
```